### PR TITLE
Autocomplete Resource Names

### DIFF
--- a/PSKubectlCompletion.psm1
+++ b/PSKubectlCompletion.psm1
@@ -82,6 +82,29 @@ function Get-AvailableOptions($lastCommand) {
     }
     return $completions;
 }
+function Get-Kubectl-Resource($resourceType) {
+    if ($null -eq $resourceType) {
+        $resourceType = $cast.Commands[2];
+    }
+    $completions = [System.Collections.ArrayList]@();
+    $kubectl = $cast.Commands[0];
+    $template = "{{range .items}}{{.metadata.name}} {{end}}"
+    $resources = Invoke-Expression "$kubectl get $resourceType --template ""$template""" -ErrorAction Ignore;
+    if ($resources.Length -gt 0) {
+        $completions += $resources.split();
+    }
+    return $completions;
+}
+function Get-Kubectl-Config($configType) {
+    $completions = [System.Collections.ArrayList]@();
+    $kubectl = $cast.Commands[0];
+    $template = "{{ range .$configType }}{{ .name }} {{ end }}"
+    $resources = Invoke-Expression "$kubectl config -o template --template=""$template"" view" -ErrorAction Ignore;
+    if ($resources.Length -gt 0) {
+        $completions += $resources.split();
+    }
+    return $completions;
+}
 function Get-KubectlCommon() {
     $flags = [System.Collections.ArrayList]@();
     $flags += ("--add-dir-header")
@@ -265,6 +288,7 @@ function Get-annotate() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-api-resources() {
@@ -465,6 +489,7 @@ function Get-attach() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource("pods");
     return $commands;
 }
 function Get-auth() {
@@ -561,6 +586,7 @@ function Get-autoscale() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-certificate() {
@@ -836,6 +862,7 @@ function Get-cordon() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource("nodes");
     return $commands;
 }
 function Get-cp() {
@@ -1009,6 +1036,7 @@ function Get-delete() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-describe() {
@@ -1056,6 +1084,7 @@ function Get-describe() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-diff() {
@@ -1151,6 +1180,7 @@ function Get-drain() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource("nodes");
     return $commands;
 }
 function Get-edit() {
@@ -1202,6 +1232,7 @@ function Get-edit() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-exec() {
@@ -1248,6 +1279,7 @@ function Get-exec() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource("pods");
     return $commands;
 }
 function Get-explain() {
@@ -1351,6 +1383,7 @@ function Get-expose() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-kustomize() {
@@ -1445,6 +1478,7 @@ function Get-label() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-logs() {
@@ -1501,6 +1535,7 @@ function Get-logs() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource("pods");
     return $commands;
 }
 function Get-options() {
@@ -1591,6 +1626,7 @@ function Get-patch() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-plugin() {
@@ -1673,6 +1709,7 @@ function Get-port-forward() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource("pods");
     return $commands;
 }
 function Get-proxy() {
@@ -1958,6 +1995,7 @@ function Get-scale() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-set() {
@@ -2055,6 +2093,7 @@ function Get-taint() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-top() {
@@ -2142,6 +2181,7 @@ function Get-uncordon() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource("nodes");
     return $commands;
 }
 function Get-version() {
@@ -2305,6 +2345,7 @@ function Get-KubectlGet() {
         if ($cast.WordToComplete -eq $cast.Commands[2]) {
             return $null;
         }
+        $flags += Get-Kubectl-Resource;
         return $flags;
     }
     $commands += $flags;
@@ -2312,6 +2353,7 @@ function Get-KubectlGet() {
 }
 function Get-CommonApiResources {
     return (
+        # plural
         "bindings",
         "componentstatuses",
         "configmaps",
@@ -2367,7 +2409,97 @@ function Get-CommonApiResources {
         "csidrivers",
         "csinodes",
         "storageclasses",
-        "volumeattachments"
+        "volumeattachments",
+
+        #singular
+        "binding",
+        "componentstatus",
+        "configmap",
+        "endpoint",
+        "event",
+        "limitrange",
+        "namespace",
+        "node",
+        "persistentvolumeclaim",
+        "persistentvolume",
+        "pod",
+        "podtemplate",
+        "replicationcontroller",
+        "resourcequota",
+        "secret",
+        "serviceaccount",
+        "service",
+        "mutatingwebhookconfiguration",
+        "validatingwebhookconfiguration",
+        "customresourcedefinition",
+        "apiservice.apiregistration",
+        "controllerrevision",
+        "daemonset",
+        "deployment",
+        "replicaset",
+        "statefulset",
+        "tokenreview.authentication",
+        "localsubjectaccessreview",
+        "selfsubjectaccessreview",
+        "selfsubjectrulesreview",
+        "subjectaccessreview",
+        "horizontalpodautoscaler",
+        "cronjob",
+        "job",
+        "lease",
+        "event",
+        "daemonset",
+        "deployment",
+        "ingress",
+        "networkpolicy",
+        "podsecuritypolicy",
+        "replicaset",
+        "ingress",
+        "networkpolicy",
+        "runtimeclass",
+        "poddisruptionbudget",
+        "podsecuritypolicy",
+        "clusterrolebinding",
+        "clusterrole",
+        "rolebinding",
+        "role",
+        "priorityclass",
+        "csidriver",
+        "csinode",
+        "storageclass",
+        "volumeattachment",
+
+        # shortname
+        "cs",
+        "cm",
+        "ep",
+        "ev",
+        "limits",
+        "ns",
+        "no",
+        "pvc",
+        "pv",
+        "po",
+        "rc",
+        "quota",
+        "sa",
+        "svc",
+        "crd",
+        "crds",
+        "ds",
+        "deploy",
+        "rs",
+        "sts",
+        "hpa",
+        "cj",
+        "csr",
+        "ev",
+        "ing",
+        "netpol",
+        "pdb",
+        "psp",
+        "pc",
+        "sc"
     );
 }
 function Get-alpha-debug() {
@@ -2883,6 +3015,7 @@ function  Get-config-delete-cluster() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Config("clusters");
     return $commands;
 }
 function  Get-config-delete-context() {
@@ -3045,6 +3178,7 @@ function  Get-config-rename-context() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Config("contexts");
     return $commands;
 }
 function  Get-config-set-cluster() {
@@ -3254,6 +3388,7 @@ function  Get-config-use-context() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Config("contexts");
     return $commands;
 }
 function  Get-config-view() {
@@ -5070,6 +5205,7 @@ function Get-top-node() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource("nodes");
     return $commands;
 }
 function Get-top-pod() {
@@ -5120,6 +5256,7 @@ function Get-top-pod() {
     $flags += ("--v=")
     $flags += ("--vmodule=")
     $commands += $flags;
+    $commands += Get-Kubectl-Resource("pods");
     return $commands;
 }
 Export-ModuleMember Register-KubectlCompletion

--- a/PSKubectlCompletion.psm1
+++ b/PSKubectlCompletion.psm1
@@ -101,7 +101,7 @@ function Get-Kubectl-Config($configType) {
     $template = "{{ range .$configType }}{{ .name }} {{ end }}"
     $resources = Invoke-Expression "$kubectl config -o template --template=""$template"" view" -ErrorAction Ignore;
     if ($resources.Length -gt 0) {
-        $completions += $resources.split();
+        $completions += $resources.trim().split();
     }
     return $completions;
 }

--- a/PSKubectlCompletion.psm1
+++ b/PSKubectlCompletion.psm1
@@ -303,7 +303,7 @@ function Get-annotate() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands +=  @(Get-Kubectl-Resources);
+    $commands += @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -601,7 +601,7 @@ function Get-autoscale() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands +=  @(Get-Kubectl-Resources);
+    $commands += @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1051,7 +1051,7 @@ function Get-delete() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands +=  @(Get-Kubectl-Resources);
+    $commands += @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1099,7 +1099,7 @@ function Get-describe() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands +=  @(Get-Kubectl-Resources);
+    $commands += @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1247,7 +1247,7 @@ function Get-edit() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands +=  @(Get-Kubectl-Resources);
+    $commands += @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1398,7 +1398,7 @@ function Get-expose() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands +=  @(Get-Kubectl-Resources);
+    $commands += @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1493,7 +1493,7 @@ function Get-label() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands +=  @(Get-Kubectl-Resources);
+    $commands += @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1641,7 +1641,7 @@ function Get-patch() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands +=  @(Get-Kubectl-Resources);
+    $commands += @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -2010,7 +2010,7 @@ function Get-scale() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands +=  @(Get-Kubectl-Resources);
+    $commands += @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -2108,7 +2108,7 @@ function Get-taint() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands +=  @(Get-Kubectl-Resources);
+    $commands += @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }

--- a/PSKubectlCompletion.psm1
+++ b/PSKubectlCompletion.psm1
@@ -91,7 +91,7 @@ function Get-Kubectl-Resource($resourceType) {
     $template = "{{range .items}}{{.metadata.name}} {{end}}"
     $resources = Invoke-Expression "$kubectl get $resourceType --template ""$template""" -ErrorAction Ignore;
     if ($resources.Length -gt 0) {
-        $completions += $resources.split();
+        $completions += $resources.trim().split();
     }
     return $completions;
 }

--- a/PSKubectlCompletion.psm1
+++ b/PSKubectlCompletion.psm1
@@ -82,7 +82,7 @@ function Get-AvailableOptions($lastCommand) {
     }
     return $completions;
 }
-function Get-Kubectl-Resource($resourceType) {
+function Get-Kubectl-Resources($resourceType) {
     if ($null -eq $resourceType) {
         $resourceType = $cast.Commands[2];
     }
@@ -287,8 +287,8 @@ function Get-annotate() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources;
     $commands += $flags;
-    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-api-resources() {
@@ -488,8 +488,8 @@ function Get-attach() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources("pods");
     $commands += $flags;
-    $commands += Get-Kubectl-Resource("pods");
     return $commands;
 }
 function Get-auth() {
@@ -585,8 +585,8 @@ function Get-autoscale() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources;
     $commands += $flags;
-    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-certificate() {
@@ -861,8 +861,8 @@ function Get-cordon() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources("nodes");
     $commands += $flags;
-    $commands += Get-Kubectl-Resource("nodes");
     return $commands;
 }
 function Get-cp() {
@@ -1035,8 +1035,8 @@ function Get-delete() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources;
     $commands += $flags;
-    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-describe() {
@@ -1083,8 +1083,8 @@ function Get-describe() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources;
     $commands += $flags;
-    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-diff() {
@@ -1179,8 +1179,8 @@ function Get-drain() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources("nodes");
     $commands += $flags;
-    $commands += Get-Kubectl-Resource("nodes");
     return $commands;
 }
 function Get-edit() {
@@ -1231,8 +1231,8 @@ function Get-edit() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources;
     $commands += $flags;
-    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-exec() {
@@ -1278,8 +1278,8 @@ function Get-exec() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources("pods");
     $commands += $flags;
-    $commands += Get-Kubectl-Resource("pods");
     return $commands;
 }
 function Get-explain() {
@@ -1382,8 +1382,8 @@ function Get-expose() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources;
     $commands += $flags;
-    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-kustomize() {
@@ -1477,8 +1477,8 @@ function Get-label() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources;
     $commands += $flags;
-    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-logs() {
@@ -1534,8 +1534,8 @@ function Get-logs() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources("pods");
     $commands += $flags;
-    $commands += Get-Kubectl-Resource("pods");
     return $commands;
 }
 function Get-options() {
@@ -1625,8 +1625,8 @@ function Get-patch() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources;
     $commands += $flags;
-    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-plugin() {
@@ -1708,8 +1708,8 @@ function Get-port-forward() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources("pods");
     $commands += $flags;
-    $commands += Get-Kubectl-Resource("pods");
     return $commands;
 }
 function Get-proxy() {
@@ -1994,8 +1994,8 @@ function Get-scale() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources;
     $commands += $flags;
-    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-set() {
@@ -2092,8 +2092,8 @@ function Get-taint() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources;
     $commands += $flags;
-    $commands += Get-Kubectl-Resource;
     return $commands;
 }
 function Get-top() {
@@ -2180,8 +2180,8 @@ function Get-uncordon() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources("nodes");
     $commands += $flags;
-    $commands += Get-Kubectl-Resource("nodes");
     return $commands;
 }
 function Get-version() {
@@ -2345,8 +2345,8 @@ function Get-KubectlGet() {
         if ($cast.WordToComplete -eq $cast.Commands[2]) {
             return $null;
         }
-        $flags += Get-Kubectl-Resource;
-        return $flags;
+        $resources = Get-Kubectl-Resources;
+        return $resources += $flags;
     }
     $commands += $flags;
     return $commands;
@@ -5204,8 +5204,8 @@ function Get-top-node() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources("nodes");
     $commands += $flags;
-    $commands += Get-Kubectl-Resource("nodes");
     return $commands;
 }
 function Get-top-pod() {
@@ -5255,8 +5255,8 @@ function Get-top-pod() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
+    $commands += Get-Kubectl-Resources("pods");
     $commands += $flags;
-    $commands += Get-Kubectl-Resource("pods");
     return $commands;
 }
 Export-ModuleMember Register-KubectlCompletion

--- a/PSKubectlCompletion.psm1
+++ b/PSKubectlCompletion.psm1
@@ -303,7 +303,7 @@ function Get-annotate() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources;
+    $commands +=  @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -504,7 +504,7 @@ function Get-attach() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources("pods");
+    $commands += @(Get-Kubectl-Resources("pods"));
     $commands += $flags;
     return $commands;
 }
@@ -601,7 +601,7 @@ function Get-autoscale() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources;
+    $commands +=  @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -877,7 +877,7 @@ function Get-cordon() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources("nodes");
+    $commands += @(Get-Kubectl-Resources("nodes"));
     $commands += $flags;
     return $commands;
 }
@@ -1051,7 +1051,7 @@ function Get-delete() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources;
+    $commands +=  @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1099,7 +1099,7 @@ function Get-describe() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources;
+    $commands +=  @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1195,7 +1195,7 @@ function Get-drain() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources("nodes");
+    $commands += @(Get-Kubectl-Resources("nodes"));
     $commands += $flags;
     return $commands;
 }
@@ -1247,7 +1247,7 @@ function Get-edit() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources;
+    $commands +=  @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1294,7 +1294,7 @@ function Get-exec() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources("pods");
+    $commands += @(Get-Kubectl-Resources("pods"));
     $commands += $flags;
     return $commands;
 }
@@ -1398,7 +1398,7 @@ function Get-expose() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources;
+    $commands +=  @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1493,7 +1493,7 @@ function Get-label() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources;
+    $commands +=  @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1550,7 +1550,7 @@ function Get-logs() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources("pods");
+    $commands += @(Get-Kubectl-Resources("pods"));
     $commands += $flags;
     return $commands;
 }
@@ -1641,7 +1641,7 @@ function Get-patch() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources;
+    $commands +=  @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -1724,7 +1724,7 @@ function Get-port-forward() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources("pods");
+    $commands += @(Get-Kubectl-Resources("pods"));
     $commands += $flags;
     return $commands;
 }
@@ -2010,7 +2010,7 @@ function Get-scale() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources;
+    $commands +=  @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -2108,7 +2108,7 @@ function Get-taint() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources;
+    $commands +=  @(Get-Kubectl-Resources);
     $commands += $flags;
     return $commands;
 }
@@ -2196,7 +2196,7 @@ function Get-uncordon() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources("nodes");
+    $commands += @(Get-Kubectl-Resources("nodes"));
     $commands += $flags;
     return $commands;
 }
@@ -2361,7 +2361,7 @@ function Get-KubectlGet() {
         if ($cast.WordToComplete -eq $cast.Commands[2]) {
             return $null;
         }
-        $resources = Get-Kubectl-Resources;
+        $resources =  @(Get-Kubectl-Resources);
         return $resources += $flags;
     }
     $commands += $flags;
@@ -5220,7 +5220,7 @@ function Get-top-node() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources("nodes");
+    $commands += @(Get-Kubectl-Resources("nodes"));
     $commands += $flags;
     return $commands;
 }
@@ -5271,7 +5271,7 @@ function Get-top-pod() {
     $flags += ("--username=")
     $flags += ("--v=")
     $flags += ("--vmodule=")
-    $commands += Get-Kubectl-Resources("pods");
+    $commands += @(Get-Kubectl-Resources("pods"));
     $commands += $flags;
     return $commands;
 }


### PR DESCRIPTION
Closes #2 

* Use resource names from the kubernetes cluster to provide autocomplete for commands
    * Only populate names from the correct resource types in the current context
* Use cluster and context names from the kubernetes config
* Add singular and shortnames for the resources so that `kubectl get hpa e<tab>` would work as expected.